### PR TITLE
Use in scrollable div, not just on body scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,39 @@ those elements within the DOM.
   </ScrollTrigger>
 ```
 
+You can also use inside of a scrollable container.
+
+```jsx
+  /** 
+   * Scrollable div container is needed
+   * 
+   * We need the 'ref' from this container div, since this component will be loaded before our 'ref',
+   * is ready I find it easier to store the 'ref' in state. 
+   */
+  const [myRef, setMyRef] = useState();
+  <div ref={r => setMyRef(r)} style={{ height: '300px', overflow: 'scroll'}}>
+    {/** 
+      * ScrollTrigger must use the 'ref' inside of the 'containerRef' prop!
+      *  
+      * Use an array of components. This allows you to trigger when a component
+      * becomes visible within the scrollable div 
+      */}
+    {myObjects.map((obj, index) => {
+      return (
+        <ScrollTrigger                     
+          containerRef={myRef} 
+          onEnter={e => alert(`${obj.attribute} at index ${index} is now visible inside scrollable div!`)} 
+          onExit={e => alert(`${obj.attribute} at index ${index} is no longer visible inside scrollable div!`)} 
+          onProgress={e => alert(`${obj.attribute} Progress: ${e}`)} 
+          key={`${obj.attribute}_${index}`} 
+        >
+          <SomeOtherComponent someProp={obj.attribute} />
+        </ScrollTrigger>
+      )
+    })}
+  </div>
+```
+
 The beauty of this component is its flexibility. I’ve used it to trigger
 AJAX requests based on either the `onEnter` or `progress` of the component within
 the viewport. Or, as a way to control animations or other transitions that you

--- a/src/index.js
+++ b/src/index.js
@@ -5,189 +5,239 @@ import throttle from 'lodash.throttle';
 import cleanProps from 'clean-react-props';
 
 class ScrollTrigger extends Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.onScrollThrottled = throttle(this.onScroll.bind(this), props.throttleScroll, {
-      trailing: false,
-    });
-
-    this.onResizeThrottled = throttle(this.onResize.bind(this), props.throttleResize, {
-      trailing: false,
-    });
-
-    this.state = {
-      inViewport: false,
-      progress: 0,
-      lastScrollPosition: null,
-      lastScrollTime: null,
-    };
-  }
-
-  componentDidMount() {
-    addEventListener('resize', this.onResizeThrottled);
-    addEventListener('scroll', this.onScrollThrottled);
-
-    if (this.props.triggerOnLoad) {
-      this.checkStatus();
-    }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevProps.throttleScroll !== this.props.throttleScroll) {
-      removeEventListener('scroll', this.onScrollThrottled);
-      this.onScrollThrottled = throttle(this.onScroll.bind(this), this.props.throttleScroll, {
-        trailing: false,
-      });
-      addEventListener('scroll', this.onScrollThrottled);
-    }
-
-    if (prevProps.throttleResize !== this.props.throttleResize) {
-      removeEventListener('resize', this.onResizeThrottled);
-      this.onResizeThrottled = throttle(this.onResize.bind(this), this.props.throttleResize, {
-        trailing: false,
-      });
-      addEventListener('resize', this.onResizeThrottled);
-    }
-  }
-
-  componentWillUnmount() {
-    removeEventListener('resize', this.onResizeThrottled);
-    removeEventListener('scroll', this.onScrollThrottled);
-  }
-
-  onResize() {
-    this.checkStatus();
-  }
-
-  onScroll() {
-    this.checkStatus();
-  }
-
-  checkStatus() {
-    const {
-      containerRef,
-      onEnter,
-      onExit,
-      onProgress,
-    } = this.props;
-
-    const {
-      lastScrollPosition,
-      lastScrollTime,
-    } = this.state;
-
-    const element = ReactDOM.findDOMNode(this.element);
-    const elementRect = element.getBoundingClientRect();
-    const viewportStart = 0;
-    const scrollingElement = typeof containerRef === 'string'
-      ? document.querySelector(containerRef)
-      : containerRef;
-    const viewportEnd = containerRef === document.documentElement
-      ? Math.max(containerRef.clientHeight, window.innerHeight || 0)
-      : scrollingElement.clientHeight;
-    const inViewport = elementRect.top <= viewportEnd && elementRect.bottom >= viewportStart;
-
-    const position = window.scrollY;
-    const velocity = lastScrollPosition && lastScrollTime
-      ? Math.abs((lastScrollPosition - position) / (lastScrollTime - Date.now()))
-      : null;
-
-    if (inViewport) {
-      const progress = Math.max(0, Math.min(1, 1 - (elementRect.bottom / (viewportEnd + elementRect.height))));
-
-      if (!this.state.inViewport) {
-        this.setState({
-          inViewport,
+        this.onScrollThrottled = throttle(this.onScroll.bind(this), props.throttleScroll, {
+            trailing: false,
         });
 
-        onEnter({
-          progress,
-          velocity,
-        }, this);
-      }
+        this.onResizeThrottled = throttle(this.onResize.bind(this), props.throttleResize, {
+            trailing: false,
+        });
 
-      onProgress({
-        progress,
-        velocity,
-      }, this);
-
-      this.setState({
-        lastScrollPosition: position,
-        lastScrollTime: Date.now(),
-      });
-      return;
+        this.state = {
+            isCustomContainerRef: false,
+            inViewport: false,
+            progress: 0,
+            lastScrollPosition: null,
+            lastScrollTime: null,
+        };
     }
 
-    if (this.state.inViewport) {
-      const progress = elementRect.top <= viewportEnd ? 1 : 0;
+    componentDidMount() {
+        // Tells us if a custom 'containerRef' has been supplied as a prop.    
+        if (this.props.containerRef !== (document.documentElement || 'html')) {
+            this.setState({ isCustomContainerRef: true });
+            this.props.containerRef.addEventListener('resize', this.onResizeThrottled)
+            this.props.containerRef.addEventListener('scroll', this.onScrollThrottled);
+        } else {
+            addEventListener('resize', this.onResizeThrottled);
+            addEventListener('scroll', this.onScrollThrottled);
+        }
 
-      this.setState({
-        lastScrollPosition: position,
-        lastScrollTime: Date.now(),
-        inViewport,
-        progress,
-      });
-
-      onProgress({
-        progress,
-        velocity,
-      }, this);
-
-      onExit({
-        progress,
-        velocity,
-      }, this);
+        if (this.props.triggerOnLoad) {
+            this.checkStatus();
+        }
     }
-  }
 
-  render() {
-    const {
-      children,
-      component,
-    } = this.props;
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.throttleScroll !== this.props.throttleScroll) {
+            this.onScrollThrottled = throttle(this.onScroll.bind(this), this.props.throttleScroll, {
+                trailing: false,
+            });
 
-    const elementMethod = React.isValidElement(component)
-      ? 'cloneElement'
-      : 'createElement';
+            if (this.state.isCustomContainerRef) {
+                this.props.containerRef.removeEventListener('scroll', this.onScrollThrottled);
+                this.props.containerRef.addEventListener('scroll', this.onScrollThrottled);
+            } else {
+                removeEventListener('scroll', this.onScrollThrottled);
+                addEventListener('scroll', this.onScrollThrottled);
+            }
+        }
 
-    return React[elementMethod](component, {
-        ...cleanProps(this.props, ['onProgress']),
-        ref: (element) => {
-          this.element = element;
+
+        if (prevProps.throttleResize !== this.props.throttleResize) {
+            this.onResizeThrottled = throttle(this.onResize.bind(this), this.props.throttleResize, {
+                trailing: false,
+            });
+
+            if (this.state.isCustomContainerRef) {
+                this.props.containerRef.removeEventListener('resize', this.onResizeThrottled);
+                this.props.containerRef.addEventListener('resize', this.onResizeThrottled);
+            } else {
+                removeEventListener('resize', this.onResizeThrottled);
+                addEventListener('resize', this.onResizeThrottled);
+            }
+        }
+
+        if (prevProps.containerRef !== this.props.containerRef) {
+            // Tells us if a custom 'containerRef' has been supplied as a prop.  
+            if (this.props.containerRef !== (document.documentElement || 'html')) {
+                this.setState({ isCustomContainerRef: true });
+                removeEventListener('resize', this.onResizeThrottled);
+                removeEventListener('scroll', this.onScrollThrottled);
+                this.props.containerRef.addEventListener('resize', this.onResizeThrottled)
+                this.props.containerRef.addEventListener('scroll', this.onScrollThrottled);
+            } else {
+                this.setState({ isCustomContainerRef: false });
+                this.props.containerRef.removeEventListener('resize', this.onResizeThrottled);
+                this.props.containerRef.removeEventListener('scroll', this.onScrollThrottled);
+                addEventListener('resize', this.onResizeThrottled);
+                addEventListener('scroll', this.onScrollThrottled);
+            }
+            this.checkStatus();
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.state.isCustomContainerRef) {
+            this.props.containerRef.removeEventListener('resize', this.onResizeThrottled);
+            this.props.containerRef.removeEventListener('scroll', this.onScrollThrottled);
+        } else {
+            removeEventListener('resize', this.onResizeThrottled);
+            removeEventListener('scroll', this.onScrollThrottled);
+        }
+    }
+
+    onResize() {
+        this.checkStatus();
+    }
+
+    onScroll() {
+        this.checkStatus();
+    }
+
+    checkStatus() {
+        const {
+            containerRef,
+            onEnter,
+            onExit,
+            onProgress,
+        } = this.props;
+
+        const {
+            lastScrollPosition,
+            lastScrollTime,
+        } = this.state;
+
+        const element = ReactDOM.findDOMNode(this.element);
+        const elementRect = element.getBoundingClientRect();
+        const viewportStart = 0;
+
+        const scrollingElement = typeof containerRef === 'string'
+            ? document.querySelector(containerRef)
+            : containerRef;
+
+        const viewportEnd = containerRef === document.documentElement
+            ? Math.max(containerRef.clientHeight, window.innerHeight || 0)
+            : scrollingElement.clientHeight;
+
+        const inViewport = elementRect.top <= viewportEnd && elementRect.bottom >= viewportStart;
+
+        const position = this.state.isCustomContainerRef
+            ? containerRef.scrollTop
+            : window.scrollY;
+
+        const velocity = lastScrollPosition && lastScrollTime
+            ? Math.abs((lastScrollPosition - position) / (lastScrollTime - Date.now()))
+            : null;
+
+        if (inViewport) {
+            const progress = Math.max(0, Math.min(1, 1 - (elementRect.bottom / (viewportEnd + elementRect.height))));
+
+            if (!this.state.inViewport) {
+                this.setState({
+                    inViewport,
+                });
+
+                onEnter({
+                    progress,
+                    velocity,
+                }, this);
+            }
+
+            onProgress({
+                progress,
+                velocity,
+            }, this);
+
+            this.setState({
+                lastScrollPosition: position,
+                lastScrollTime: Date.now(),
+            });
+            return;
+        }
+
+        if (this.state.inViewport) {
+            const progress = elementRect.top <= viewportEnd ? 1 : 0;
+
+            this.setState({
+                lastScrollPosition: position,
+                lastScrollTime: Date.now(),
+                inViewport,
+                progress,
+            });
+
+            onProgress({
+                progress,
+                velocity,
+            }, this);
+
+            onExit({
+                progress,
+                velocity,
+            }, this);
+        }
+    }
+
+    render() {
+        const {
+            children,
+            component,
+        } = this.props;
+
+        const elementMethod = React.isValidElement(component)
+            ? 'cloneElement'
+            : 'createElement';
+
+        return React[elementMethod](component, {
+            ...cleanProps(this.props, ['onProgress']),
+            ref: (element) => {
+                this.element = element;
+            },
         },
-      },
-      children,
-    );
-  }
+            children,
+        );
+    }
 }
 
 ScrollTrigger.propTypes = {
-  component: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.node,
-  ]),
-  containerRef: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.string,
-  ]),
-  throttleResize: PropTypes.number,
-  throttleScroll: PropTypes.number,
-  triggerOnLoad: PropTypes.bool,
-  onEnter: PropTypes.func,
-  onExit: PropTypes.func,
-  onProgress: PropTypes.func,
+    component: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.node,
+    ]),
+    containerRef: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.string,
+    ]),
+    throttleResize: PropTypes.number,
+    throttleScroll: PropTypes.number,
+    triggerOnLoad: PropTypes.bool,
+    onEnter: PropTypes.func,
+    onExit: PropTypes.func,
+    onProgress: PropTypes.func,
 };
 
 ScrollTrigger.defaultProps = {
-  component: 'div',
-  containerRef: (typeof document !== 'undefined') ? document.documentElement : 'html',
-  throttleResize: 100,
-  throttleScroll: 100,
-  triggerOnLoad: true,
-  onEnter: () => {},
-  onExit: () => {},
-  onProgress: () => {},
+    component: 'div',
+    containerRef: (typeof document !== 'undefined') ? document.documentElement : 'html',
+    throttleResize: 100,
+    throttleScroll: 100,
+    triggerOnLoad: true,
+    onEnter: () => { },
+    onExit: () => { },
+    onProgress: () => { },
 };
 
 export default ScrollTrigger;


### PR DESCRIPTION
I am unsure if this PR conflicts with the intended use of this component, specifically the `containerRef` property, but this modification solved a use case I had.  It also solves [this](https://github.com/ryanhefner/react-scroll-trigger/issues/66) open issue.

You can now use a container which will trigger all events for nested `ScrollTrigger` components.

I have built an detailed live demo, which you [can view here](https://react-scroll-trigger-container.litpoc.com/), as well as the demo code, which is [at this repo](https://github.com/oze4/react-scroll-trigger-container/blob/master/src/react-scroll-trigger.js).